### PR TITLE
Skip range collected items if PipeRequestEvent is cancelled

### DIFF
--- a/src/main/java/com/sk89q/craftbook/mechanics/ic/gates/world/items/RangedCollector.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/ic/gates/world/items/RangedCollector.java
@@ -138,6 +138,10 @@ public class RangedCollector extends AbstractSelfTriggeredIC {
                     PipeRequestEvent event = new PipeRequestEvent(pipe, new ArrayList<ItemStack>(Collections.singletonList(stack)), getBackBlock());
                     Bukkit.getPluginManager().callEvent(event);
 
+                    if (event.isCancelled()) {
+                        continue;
+                    }
+
                     if(event.getItems().isEmpty()) {
                         entity.remove();
                         return true;


### PR DESCRIPTION
This is needed for some plugins like Shop that uses items on top of chests for display items to prevent item duplication.